### PR TITLE
Update medusa.py

### DIFF
--- a/medusa.py
+++ b/medusa.py
@@ -682,7 +682,7 @@ catch (err) {
                 delay = line.split()[1]
                 hooks.append("\n\nsetTimeout(function() {\n")
 
-            hooks.append("\n\nJava.perform(function() { \ntry {\ndisplayAppInfo();\n")
+            hooks.append("setImmediate(function() {\n\nJava.perform(function() { \ntry {\ndisplayAppInfo();\n")
             for mod in self.modManager.staged:
                 if 'JNICalls' in mod.path and not jni_prolog_added:
                     hooks.append("""
@@ -702,7 +702,7 @@ catch (err) {
         colorLog("------------Error Log start-------------",{ c:Color.Red })
         console.log(error);
         colorLog("------------Error Log EOF---------------",{ c:Color.Red })
-      } } );"""
+     } })} );"""
             if delay != '':
                 hooks.append(epilog[:-1])
                 hooks.append("}}, {});".format(delay))


### PR DESCRIPTION
Updated the 'do_compile' function to add the 'setImmediate' to the hooks. In that way, when attaching methods such as the 'onCreate' which are fastest that Frida, it will try to be called on Frida’s JavaScript thread as soon as possible. This could avoid the user to think that a method is not called when hooking and tracing it. More information about it in https://frida.re/docs/javascript-api/