### PR TITLE
Two new code loading modules + new run / list option

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ A Medusa module is essentially a Frida script on steroids combined with multiple
        
    		hook.function.implementation = function() {
    			console.log("Info: entered target method");		
-       }
+      }
    
    	});  
    ```
@@ -279,10 +279,11 @@ A Medusa module is essentially a Frida script on steroids combined with multiple
        
    		hook.function.implementation = function() {
    			console.log("Info: entered target method");		
-       }
+      }
    ```
 
-2. **Insert the modified code in the "code" segment of the following json object:**
+2. **Insert the modified code in the "code" segment of the following json object:** Do not forget to escape all 
+quotes (`\"`).
 
    ```json
    {

--- a/medusa.py
+++ b/medusa.py
@@ -587,7 +587,6 @@ catch (err) {
         for i in range(len(self.packages)):
             print('[{}] {}'.format(i, self.packages[i]))
 
-
     def do_dump(self, line):
         pkg = line.split(' ')[0].strip()
         if pkg == '':
@@ -826,9 +825,21 @@ catch (err) {
             if length == 1:
                 self.run_frida(False, False, line, self.device)
             elif length == 2:
-                print(flags[1])
+                
                 if '-f' in flags[0]:
+                    print(flags[1])
                     self.run_frida(True, False, flags[1], self.device)
+                
+                if '-n' in flags[0]:
+                    try:
+                        if len(self.packages) == 0:
+                            self.refreshPackages()
+                        #print(flags[1])
+                        package_name = self.packages[int(flags[1])]
+                        #print("package name: ", package_name)
+                        self.run_frida(True, False, package_name, self.device)
+                    except (IndexError, TypeError) as error:
+                        print('Invalid package number')
 
                 else:
                     print('Invalid flag given!')
@@ -1071,6 +1082,8 @@ Apk Directory: {}\n""".format(appname,filesDirectory,cacheDirectory,externalCach
 
                         - run        [package name] : Initiate a Frida session and attach to the selected package
                         - run -f     [package name] : Initiate a Frida session and spawn the selected package
+                        - run -n     [package num]  : Initiate a Frida session and spawn the package referenced by 
+                                                      this number
                         - dump       [package_name] : Dump the requested package name (works for most unpackers)
                         - loaddevice                : Load or reload a device
                 ====================================================================================================

--- a/medusa.py
+++ b/medusa.py
@@ -989,20 +989,23 @@ Apk Directory: {}\n""".format(appname,filesDirectory,cacheDirectory,externalCach
 
 
     def do_list(self,line):
-        try:
-            package = line.split()[0]
-            option = line.split()[1]
-            dumpsys = os.popen('adb -s {} shell dumpsys package {}'.format(self.device.id,package))
-            if option == "path":
-                print('-'*20+package+' '+"paths"+'-'*20)
-                for ln in dumpsys:
-                    for keyword in ["resourcePath","codePath","legacyNativeLibraryDir","primaryCpuAbi"]:
-                        if keyword in ln:
-                            print(ln,end='')
+        if len(line.split()) == 0:
+            self.init_packages()
+        else:
+            try:    
+                package = line.split()[0]
+                option = line.split()[1]
+                dumpsys = os.popen('adb -s {} shell dumpsys package {}'.format(self.device.id,package))
+                if option == "path":
+                    print('-'*20+package+' '+"paths"+'-'*20)
+                    for ln in dumpsys:
+                        for keyword in ["resourcePath","codePath","legacyNativeLibraryDir","primaryCpuAbi"]:
+                            if keyword in ln:
+                                print(ln,end='')
 
-            print("-"*31+'EOF'+'-'*len(package)+'-'*12)
-        except Exception as e:
-            print(e)
+                print("-"*31+'EOF'+'-'*len(package)+'-'*12)
+            except Exception as e:
+                print(e)
 
 
     def complete_list(self, text, line, begidx, endidx):
@@ -1082,8 +1085,8 @@ Apk Directory: {}\n""".format(appname,filesDirectory,cacheDirectory,externalCach
 
                         - run        [package name] : Initiate a Frida session and attach to the selected package
                         - run -f     [package name] : Initiate a Frida session and spawn the selected package
-                        - run -n     [package num]  : Initiate a Frida session and spawn the package referenced by 
-                                                      this number
+                        - run -n     [package num]  : Initiate a Frida session and spawn the 3rd party package 
+                                                      number num (listed by "list")
                         - dump       [package_name] : Dump the requested package name (works for most unpackers)
                         - loaddevice                : Load or reload a device
                 ====================================================================================================
@@ -1091,6 +1094,7 @@ Apk Directory: {}\n""".format(appname,filesDirectory,cacheDirectory,externalCach
                 HELPERS:
 
                         - type 'text'               : Send a text to the device
+                        - list                      : List 3rd party packages
                         - list 'package_name' path  : List data/app paths of 3rd party packages 
                         - status                    : Print Current Package/Libs/Native-Functions
                         - shell                     : Open an interactive shell

--- a/modules/code_loading/dump_dyndex.med
+++ b/modules/code_loading/dump_dyndex.med
@@ -66,10 +66,12 @@
         return this.$init(filename, librarySearchPath, parent);
     }
 
-    delegateLoader.$init.overload('java.lang.String', 'java.lang.String', 'java.lang.ClassLoader', 'boolean').implementation = function(filename, librarySearchPath, parent, resourceLoading) {
-        colorLog('DelegateLastClassLoader(f,l,p,b) called: '+filename, {c: Color.Yellow});
-        dump(filename);
-        return this.$init(filename, librarySearchPath, parent, resourceLoading);
+    if (Java.use('android.os.Build$VERSION').SDK_INT.value > 28) {
+        delegateLoader.$init.overload('java.lang.String', 'java.lang.String', 'java.lang.ClassLoader', 'boolean').implementation = function(filename, librarySearchPath, parent, resourceLoading) {
+            colorLog('DelegateLastClassLoader(f,l,p,b) called: '+filename, {c: Color.Yellow});
+            dump(filename);
+            return this.$init(filename, librarySearchPath, parent, resourceLoading);
+        }
     }
 
     memoryLoader.$init.overload('java.nio.ByteBuffer', 'java.lang.ClassLoader').implementation = function(dexbuffer, loader) {

--- a/modules/code_loading/dump_dyndex.med
+++ b/modules/code_loading/dump_dyndex.med
@@ -1,0 +1,105 @@
+{
+    "Name": "code_loading/dump_dyndex",
+    "Description": "Dumps DEX files loaded via DexClassLoader/PathClassLoader/DelegateLastClassLoader/InMemoryDexClassLoader. The other dump_dex script will dump any DEX in memory including the current DEX. Malicious payloads are usually rather loaded dynamically",
+    "Help": "original script: https://github.com/cryptax/misc-code/blob/master/frida_hooks/dex-dump.js",
+    "Code": 
+    "
+    const classLoader = Java.use('dalvik.system.DexClassLoader');
+    const pathLoader = Java.use('dalvik.system.PathClassLoader');
+    const memoryLoader = Java.use('dalvik.system.InMemoryDexClassLoader');
+    const delegateLoader = Java.use('dalvik.system.DelegateLastClassLoader');
+    const File = Java.use('java.io.File');
+    const FileInputStream = Java.use(\"java.io.FileInputStream\");
+    const FileOutputStream = Java.use(\"java.io.FileOutputStream\");
+    const ActivityThread = Java.use(\"android.app.ActivityThread\");
+    var counter = 0;
+
+    function dump(filename) {
+        var sourceFile = File.$new(filename);
+        var fis = FileInputStream.$new(sourceFile);
+        var inputChannel = fis.getChannel();
+
+        var application = ActivityThread.currentApplication();
+        if (application == null) return ;
+        var context = application.getApplicationContext();
+
+        // you cannot dump to /sdcard unless the app has rights to!
+        var fos = context.openFileOutput('dump_'+counter, 0);
+        counter = counter + 1;
+
+        var outputChannel = fos.getChannel();
+        inputChannel.transferTo(0, inputChannel.size(), outputChannel);
+        fis.close();
+        fos.close();
+
+        console.log(\"[*] Dumped \"+filename+\" to dump_\"+counter);
+    }
+
+
+    classLoader.$init.implementation = function(filename, b, c, d) {
+	    colorLog('DexClassLoader called:', {c: Color.Green});
+        dump(filename);
+        return this.$init(filename, b, c, d);
+    }
+
+    pathLoader.$init.overload('java.lang.String', 'java.lang.ClassLoader').implementation = function(filename, parent) {
+        console.log(\"[*] PathClassLoader(file=\"+filename+', parent)');
+        dump(filename);
+        return this.$init(filename, parent);
+    }
+
+    pathLoader.$init.overload('java.lang.String', 'java.lang.String', 'java.lang.ClassLoader').implementation = function(filename, librarySearchPath, parent) {
+        console.log(\"[*] PathClassLoader(file=\"+filename+\", librarySearchPath, parent)\");
+        dump(filename);
+        return this.$init(filename, librarySearchPath, parent);
+    }
+
+    delegateLoader.$init.overload('java.lang.String', 'java.lang.ClassLoader').implementation = function(filename, parent) {
+        console.log(\"[*] DelegateLastClassLoader(file=\"+filename+', parent)');
+        dump(filename);
+        return this.$init(filename, parent);
+    }
+
+    delegateLoader.$init.overload('java.lang.String', 'java.lang.String', 'java.lang.ClassLoader').implementation = function(filename, librarySearchPath, parent) {
+        console.log(\"[*] DelegateLastClassLoader(file=\"+filename+\", librarySearchPath, parent)\");
+        dump(filename);
+        return this.$init(filename, librarySearchPath, parent);
+    }
+
+    delegateLoader.$init.overload('java.lang.String', 'java.lang.String', 'java.lang.ClassLoader', 'boolean').implementation = function(filename, librarySearchPath, parent, resourceLoading) {
+        console.log(\"[*] DelegateLastClassLoader(file=\"+filename+\", librarySearchPath, parent, resourceLoading)\");
+        dump(filename);
+        return this.$init(filename, librarySearchPath, parent, resourceLoading);
+    }
+
+    memoryLoader.$init.overload('java.nio.ByteBuffer', 'java.lang.ClassLoader').implementation = function(dexbuffer, loader) {
+	    var object = this.$init(dexbuffer, loader);
+
+	    /* dexbuffer is a Java ByteBuffer */
+	    var remaining = dexbuffer.remaining();
+	
+        var filename = 'dump_' + counter;
+        counter = counter + 1;
+	    console.log(\"[*] Opening file name=\"+filename+\" to write \"+remaining+\" bytes\");
+
+	    const f = new File(filename,'wb');
+	    var buf = new Uint8Array(remaining);
+	    for (var i=0;i<remaining;i++) {
+	        buf[i] = dexbuffer.get();
+	        //debug: console.log(\"buf[\"+i+\"]=\"+buf[i]);
+	    }
+	    console.log(\"[*] Writing \"+remaining+\" bytes...\");
+	    f.write(buf);
+	    f.close();
+	
+	    // checking
+	    remaining = dexbuffer.remaining();
+	    if (remaining > 0) {
+	        console.log(\"[-] Error: There are \"+remaining+\" remaining bytes!\");
+	    } else {
+	        console.log(\"[+] Dex dumped successfully in \"+filename);
+	    }
+        return object;
+    }"
+
+}

--- a/modules/code_loading/dump_dyndex.med
+++ b/modules/code_loading/dump_dyndex.med
@@ -32,42 +32,42 @@
         fis.close();
         fos.close();
 
-        console.log(\"[*] Dumped \"+filename+\" to dump_\"+counter);
+        console.log(\"[+] Dumped \"+filename+\" to dump_\"+counter);
     }
 
 
     classLoader.$init.implementation = function(filename, b, c, d) {
-	    colorLog('DexClassLoader called:', {c: Color.Green});
+	    colorLog('DexClassLoader called: '+filename, {c: Color.Yellow});
         dump(filename);
         return this.$init(filename, b, c, d);
     }
 
     pathLoader.$init.overload('java.lang.String', 'java.lang.ClassLoader').implementation = function(filename, parent) {
-        console.log(\"[*] PathClassLoader(file=\"+filename+', parent)');
+        colorLog('PathClassLoader(f,p) called: '+filename, {c: Color.Yellow});
         dump(filename);
         return this.$init(filename, parent);
     }
 
     pathLoader.$init.overload('java.lang.String', 'java.lang.String', 'java.lang.ClassLoader').implementation = function(filename, librarySearchPath, parent) {
-        console.log(\"[*] PathClassLoader(file=\"+filename+\", librarySearchPath, parent)\");
+        colorLog('PathClassLoader(f,l,p) called: '+filename, {c: Color.Yellow});
         dump(filename);
         return this.$init(filename, librarySearchPath, parent);
     }
 
     delegateLoader.$init.overload('java.lang.String', 'java.lang.ClassLoader').implementation = function(filename, parent) {
-        console.log(\"[*] DelegateLastClassLoader(file=\"+filename+', parent)');
+        colorLog('DelegateLastClassLoader(f,p) called: '+filename, {c: Color.Yellow});
         dump(filename);
         return this.$init(filename, parent);
     }
 
     delegateLoader.$init.overload('java.lang.String', 'java.lang.String', 'java.lang.ClassLoader').implementation = function(filename, librarySearchPath, parent) {
-        console.log(\"[*] DelegateLastClassLoader(file=\"+filename+\", librarySearchPath, parent)\");
+        colorLog('DelegateLastClassLoader(f,l,p) called: '+filename, {c: Color.Yellow});
         dump(filename);
         return this.$init(filename, librarySearchPath, parent);
     }
 
     delegateLoader.$init.overload('java.lang.String', 'java.lang.String', 'java.lang.ClassLoader', 'boolean').implementation = function(filename, librarySearchPath, parent, resourceLoading) {
-        console.log(\"[*] DelegateLastClassLoader(file=\"+filename+\", librarySearchPath, parent, resourceLoading)\");
+        colorLog('DelegateLastClassLoader(f,l,p,b) called: '+filename, {c: Color.Yellow});
         dump(filename);
         return this.$init(filename, librarySearchPath, parent, resourceLoading);
     }
@@ -80,7 +80,7 @@
 	
         var filename = 'dump_' + counter;
         counter = counter + 1;
-	    console.log(\"[*] Opening file name=\"+filename+\" to write \"+remaining+\" bytes\");
+	    console.log(\"[*] InMemoryDexClassLoader: Opening file name=\"+filename+\" to write \"+remaining+\" bytes\");
 
 	    const f = new File(filename,'wb');
 	    var buf = new Uint8Array(remaining);

--- a/modules/code_loading/load_class.med
+++ b/modules/code_loading/load_class.med
@@ -1,0 +1,25 @@
+{
+    "Name": "code_loading/load_class",
+    "Description": "Show calls to loadClass that do not come from standard Android classes",
+    "Help": "Hooks loadClass only if not from android, org, com.google and java namespaces",
+    "Code":
+    "
+    var classLoaderDef = Java.use('java.lang.ClassLoader');
+    var loadClass = classLoaderDef.loadClass.overload('java.lang.String', 'boolean');
+    var internalClasses = [ \"android.\", \"org.\", \"com.google.\", \"java.\", \"androidx.\"];
+
+    /* taken from https://github.com/eybisi/nwaystounpackmobilemalware/blob/master/dereflect.js */
+    loadClass.implementation = function(class_name, resolve) {
+        var isGood = true;
+        for (var i = 0; i < internalClasses.length; i++) {
+            if (class_name.startsWith(internalClasses[i])) {
+                isGood = false;
+            }
+        }
+        if (isGood) {
+            console.log(\"loadClass: \" + class_name);
+        }
+        return loadClass.call(this, class_name, resolve);
+    }
+    "
+}


### PR DESCRIPTION
**Two new modules**:
- code_loading/load_class: hooks loadClass but only displays them if from non-system code. I.e if this is class loading from an internal Android class, it won't show it so as not to pollute the output.
- code_loading/dump_dyndex: dumps DEX file inside the app's private when loaded through `DexClassLoader/PathClassLoader/InMemoryDexClassLoader` etc. I find this hook more helpful than the generic `dump_dex` one which dumps any DEX it finds in memory. Unfortunately, that means it also dumps itself, and I waste time analyzing a DEX I already have. With `DexClassLoader`, we're sure this is a new DEX (and for malware, most of the time this is the malicious payload).

**Additions to medusa.py:**
In my case, I typically have an Android emulator with one [malicious] sample to analyze. When medusa launches, it tells me that package `x.y.z` is installed. But then, I load modules etc and have to scroll up to find the package name to run it with `run -f`. To ease this case, I added:
- `list` command (no argument): lists all 3rd party packages. Helpful if I want to see the list again. NB. Does not modify the existing `list packagename path` command.
- `run -n NUM` command: list gives you a list of 3rd party packages referenced by a number. Then you can run the package by its number, instead of having to copy / paste a potentially ugly package name. If you have only a single 3rd party package, `run -n 0` will run that package. 

Each modification has its own commit in case you don't want them all.