### PR TITLE
bug fix

### DIFF
--- a/medusa.py
+++ b/medusa.py
@@ -1548,7 +1548,7 @@ Apk Directory: {}\n""".format(appname,filesDirectory,cacheDirectory,externalCach
             print(e)
         
 if __name__ == '__main__':
-    if 'libedit' in readline.__doc__:
+    if readline.__doc__ is not None and 'libedit' in readline.__doc__:
         readline.parse_and_bind("bind ^I rl_complete")
     else:
         readline.parse_and_bind("tab: complete")


### PR DESCRIPTION
when i typed cmd `python medusa.py` and an error found below 
```
λ python medusa.py
Traceback (most recent call last):
  File "D:\tmp\medusa\medusa.py", line 1551, in <module>
    if 'libedit' in readline.__doc__:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```
maybe we need check this valid.

os: wind10 
python V: Python 3.11.3
