### PR TITLE
Updated requirements.txt to prevent frida dependency error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ androguard==3.3.5
 click==8.0.3
 cmd2==2.3.3
 colorama==0.4.5
-frida==16.0.2
+frida==16.1.4
+frida-tools==13.2.0
 pick==2.2.0
 PyYAML==6.0.1
 requests==2.25.1


### PR DESCRIPTION
**frida** has the requirement of **frida-tools** but not all versions are compatible

Running the command `pip install -r requirements.txt --upgrade` may encounter this or a similar error
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
frida-tools 12.3.0 requires frida<17.0.0,>=16.0.9, but you have frida 16.0.2 which is incompatible.
```

Latest **frida** (v16.1.4) and **frida-tools** (v12.3.0) are compatible and have been tested to run with medusa

I made this pull request to prevent the above dependency error