### PR TITLE
mango to report on static evasion tactics

### DIFF
--- a/libraries/db.py
+++ b/libraries/db.py
@@ -12,7 +12,7 @@ class apk_db():
             self.create_db(self.connection)
 
     def create_db(self,cursor):
-        self.cursor.execute("""CREATE TABLE Application(sha256 TEXT, name TEXT, packageName TEXT, versionCode TEXT, versionName TEXT, minSdkVersion TEXT, targetSdkVersion TEXT, maxSdkVersion TEXT,permissions TEXT, libraries TEXT, debuggable TEXT, allowbackup TEXT, androidManifest TEXT, stringResources TEXT, original_filename TEXT)""")
+        self.cursor.execute("""CREATE TABLE Application(sha256 TEXT, name TEXT, packageName TEXT, versionCode TEXT, versionName TEXT, minSdkVersion TEXT, targetSdkVersion TEXT, maxSdkVersion TEXT,permissions TEXT, libraries TEXT, debuggable TEXT, allowbackup TEXT, androidManifest TEXT, stringResources TEXT, original_filename TEXT, tampered TEXT)""")
 
         self.cursor.execute("""CREATE TABLE Permissions(app_sha256 TEXT, permission TEXT, type TEXT, shortDescription TEXT, fullDescription TEXT)""")
 
@@ -139,7 +139,7 @@ class apk_db():
 
     def update_application(self,attribs):
         sql = """INSERT INTO Application(sha256,name,packageName,versionCode,versionName,minSdkVersion,
-        targetSdkVersion,maxSdkVersion,permissions,libraries, debuggable, allowbackup,androidManifest,stringResources,original_filename) values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"""
+        targetSdkVersion,maxSdkVersion,permissions,libraries, debuggable, allowbackup,androidManifest,stringResources,original_filename,tampered) values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"""
         self.execute_update(sql,attribs)
 
     def update_intent_filters(self,attribs):

--- a/libraries/libguava.py
+++ b/libraries/libguava.py
@@ -1,5 +1,8 @@
-from androguard.misc import AnalyzeAPK
-from androguard.core.bytecodes import apk
+import io
+
+from androguard.core import apk
+from apkInspector.indicators import apk_tampering_check
+
 from libraries.IntentFilter import *
 from libraries.db import *
 import hashlib
@@ -98,11 +101,19 @@ class Guava:
           activity_alias_attributes = (sha256, aliasname, enabled, exported,permission,targetActivity)
           self.application_database.update_activity_alias(activity_alias_attributes)  
 
-  def fill_application_attributes(self,parsed_apk,sha256,application,original_filename):
-    arsc = parsed_apk.get_android_resources()
-    app_attributes = (sha256,parsed_apk.get_app_name(),parsed_apk.get_package(),parsed_apk.get_androidversion_code(),parsed_apk.get_androidversion_name(),parsed_apk.get_min_sdk_version(),parsed_apk.get_target_sdk_version(),parsed_apk.get_max_sdk_version(),'|'.join(parsed_apk.get_permissions()),'|'.join(parsed_apk.get_libraries())) + (application.get(NS_ANDROID+"debuggable"), application.get(NS_ANDROID+"allowBackup"),parsed_apk.get_android_manifest_axml().get_xml(),arsc.get_string_resources(arsc.get_packages_names()[0]),original_filename)
+  def fill_application_attributes(self, parsed_apk, sha256, application, original_filename):
+      arsc = parsed_apk.get_android_resources()
+      app_attributes = (sha256, parsed_apk.get_app_name(), parsed_apk.get_package(),
+                        parsed_apk.get_androidversion_code(), parsed_apk.get_androidversion_name(),
+                        parsed_apk.get_min_sdk_version(), parsed_apk.get_target_sdk_version(),
+                        parsed_apk.get_max_sdk_version(), '|'.join(parsed_apk.get_permissions()),
+                        '|'.join(parsed_apk.get_libraries())) + (
+                       application.get(NS_ANDROID + "debuggable"), application.get(NS_ANDROID + "allowBackup"),
+                       parsed_apk.get_android_manifest_axml().get_xml(),
+                       arsc.get_string_resources(arsc.get_packages_names()[0]), original_filename,
+                       self.detect_tampering(parsed_apk))
 
-    self.application_database.update_application(app_attributes)
+      self.application_database.update_application(app_attributes)
 
   def fill_permissions(self,parsed_apk, sha256):
     app_permissions = parsed_apk.get_details_permissions()
@@ -201,4 +212,16 @@ class Guava:
   
   def delete_note(self,index):
      self.application_database.delete_note(index)
+
+  def detect_tampering(self, parsed_apk):
+      tamperings = apk_tampering_check(io.BytesIO(parsed_apk.get_raw()), False)
+      tampering_types = []
+
+      if tamperings.get("zip tampering", 0):
+          tampering_types.append("ZIP")
+
+      if tamperings.get('manifest tampering', 0):
+          tampering_types.append("MANIFEST")
+
+      return ' | '.join(tampering_types) if tampering_types else "None"
   

--- a/libraries/libmango.py
+++ b/libraries/libmango.py
@@ -1087,8 +1087,8 @@ $adb remount
                 print(display_text)
         print(Style.RESET_ALL)
 
-    def print_application_info(self,info):
-        print(Back.BLACK+Fore.RED+Style.BRIGHT+"""
+    def print_application_info(self, info):
+        print(Back.BLACK + Fore.RED + Style.BRIGHT + """
 [------------------------------------Package Details---------------------------------------]:
 |    Original Filename :{}
 |    Application Name  :{}
@@ -1100,18 +1100,20 @@ $adb remount
 |    Max SDK           :{}
 |    Sha256            :{}
 |    Debuggable        :{}
-|    Allow Backup      :{} 
+|    Allow Backup      :{}
+|    Evasion Tactics   :{}
 [------------------------------------------------------------------------------------------]
 |                          Type 'help' or 'man' for a list of commands                     |
 [------------------------------------------------------------------------------------------]
-        """.format(info[0][14],info[0][1],info[0][2],info[0][3],info[0][4],
-            info[0][5],info[0][6],info[0][7],info[0][0],info[0][10],info[0][11]) +Style.RESET_ALL)
-        print(BLUE+"[i] Notes:"+RESET)   
+        """.format(info[0][14], info[0][1], info[0][2], info[0][3], info[0][4],
+                   info[0][5], info[0][6], info[0][7], info[0][0], info[0][10], info[0][11],
+                   info[0][15]) + Style.RESET_ALL)
+        print(BLUE + "[i] Notes:" + RESET)
         notes = self.database.get_all_notes(info[0][0])
-        if len(notes)==0:
+        if len(notes) == 0:
             print("No notes found!")
         else:
-            for index,sha256,cmt in notes:
+            for index, sha256, cmt in notes:
                 print(f'{index}) {cmt}')
 
     def print_database_structure(self):

--- a/mango.py
+++ b/mango.py
@@ -1,13 +1,7 @@
-from androguard.misc import AnalyzeAPK
-from androguard.core.bytecodes import apk
-from colorama import Fore, Back, Style
-from libraries.IntentFilter import *
 from libraries.libmango import *
-from libraries.db import *
 from libraries.Questions import *
 from libraries.libguava import *
 from libraries.libadb import *
-import hashlib
 import sys, os.path
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-androguard==3.3.5
+androguard @ git+https://github.com/androguard/androguard.git@335f1d4744b28b6b5cfb2d79bb5c2c6d780ec10e
 click==8.0.3
 cmd2==2.3.3
 colorama==0.4.5


### PR DESCRIPTION
This PR offers in mango the possibility
 - to handle APKs that employ static analysis evasion methods,
 - to report, during an import, whether a static analysis evasion method was used or not. 

Given that mango utilizes androguard to gather statically information about apks and due to it is used often against malware and static analysis evasion is a feature employed by packers, i believe it would be a nice addition if it would report also whether an apk has employed methods for evading static analysis. 

The following two snippets show two examples, the first using [this](https://www.joesandbox.com/analysis/1344544) malware and the second showing a normal app.

~~~~
[------------------------------------Package Details---------------------------------------]:
|    Original Filename :/path/to/infected.apk
|    Application Name  :로젠택배
|    Package Name      :wyija.utykuvr.uwpexgh
|    Version code      :1
|    Version Name      :17.1.22
|    Mimimum SDK       :15
|    Target  SDK       :21
|    Max SDK           :None
|    Sha256            :b3561bf581721c84fd92501e2d0886b284e8fa8e7dc193e41ab300a063dfe5f3
|    Debuggable        :false
|    Allow Backup      :true
|    Evasion Tactics   :ZIP | MANIFEST
[------------------------------------------------------------------------------------------]
~~~~

~~~~
[------------------------------------Package Details---------------------------------------]:
|    Original Filename :./minimal_orig.apk
|    Application Name  :erev0s.com - Minimal
|    Package Name      :com.erev0s.minimal
|    Version code      :1
|    Version Name      :1.0
|    Mimimum SDK       :24
|    Target  SDK       :33
|    Max SDK           :None
|    Sha256            :e6e53d117986317d2c70b8ce253d02449df1b269097bc51113522d0be47128a7
|    Debuggable        :None
|    Allow Backup      :true
|    Evasion Tactics   :None
[------------------------------------------------------------------------------------------]
~~~~

Notice the `Evasion Tactics` field.

This capability is possible through [apkInspector](https://github.com/erev0s/apkInspector) (more info [here](https://erev0s.com/blog/unmasking-evasive-threats-with-apkinspector/)), which is now part of [androguard](https://github.com/androguard/androguard/commit/1a30cbabeccdf828c3ccee4b21276d997c78abc8)

Something to consider before merging is that due to androguard does not have a proper streamlined process for releases into PyPI yet ([I am working on that](https://github.com/androguard/androguard/pull/957)), I have added in the requirements the dependency based on a specific commit. In the future, once androguard releases a new version into PyPI, we can update it.


Please let me know if there any suggested edits/updates.