### PR TITLE
refactor: use local utils.google_trans_new

### DIFF
--- a/medusa.py
+++ b/medusa.py
@@ -3,7 +3,7 @@ import subprocess, platform, os, sys, readline, time, argparse, requests, re
 from urllib.parse import urlparse
 import cmd2, click, frida, random, yaml
 from libraries.dumper import dump_pkg
-from google_trans_new import google_translator
+from utils.google_trans_new import google_translator
 from libraries.natives import *
 from libraries.libadb import *
 from libraries.Questions import *

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ pick==2.2.0
 PyYAML==6.0.1
 requests==2.25.1
 urllib3==1.26.18
-google_trans_new
 apkInspector


### PR DESCRIPTION
Resolves #78 
Remove `google_trans_new` from `requirements.txt` and use local `utils.google_trans_new`