### PR TITLE
New module: DNS Logger

### DIFF
--- a/modules/http_communications/dns_logger.med
+++ b/modules/http_communications/dns_logger.med
@@ -1,0 +1,16 @@
+{
+    "Name": "http_communications/dns_logger",
+    "Description": "Print DNS lookups created by the application",
+    "Help": "Prints host from getAllByName. Reference: https://developer.android.com/reference/java/net/InetAddress",
+    "Code": "console.log('\\n[+] loading ------- DNS Logger by @giorgosioak -------\\n')
+
+    Java.perform(function () {
+        var InetAddress = Java.use('java.net.InetAddress');
+
+        // Intercept InetAddress.getAllByName(String host)
+        InetAddress['getAllByName'].implementation = function (host) {
+            console.log('[*] DNS lookup for: ' + host);
+            return this.getAllByName(host);
+        };
+    });"
+}


### PR DESCRIPTION
Added a basic DNS Logger that hooks on [java.net.InetAddress](https://developer.android.com/reference/java/net/InetAddress) getAllByName method.

Known limitation: It won't work properly while using a VPN connection on the Android device.