### PR TITLE
Ability to pull, patch and install bundled apks

### DIFF
--- a/libraries/libmango.py
+++ b/libraries/libmango.py
@@ -679,15 +679,31 @@ $adb remount
     def do_pull(self, line):
         """Usage: pull com.foo.bar
         Extracts an apk from the device and saves it as 'base.apk' in the working directory.
-        Use it in combination with the tab key to see available packages"""
+        Use it in combination with the tab key to see available packages
+        '-a' flag to pull all the split_config* apks"""
 
-        package = line.split(' ')[0]
+        switch = line.split(' ')[0]
+        pull_all = False
+
+        if '-a' in switch:
+            package = line.split(' ')[1]
+            pull_all = True
+        else:
+            package = line.split(' ')[0]
+
         try:
             base_apk = os.popen(
                 f"adb -s {self.device.id} shell pm path {package} | grep base.apk | cut -d ':' -f 2").read()
             print("Extracting: " + base_apk)
             output = os.popen("adb -s {} pull {}".format(self.device.id, base_apk, package)).read()
             print(output)
+            if pull_all:
+                split_apks = os.popen(
+                f"adb -s {self.device.id} shell pm path {package} | grep split | cut -d ':' -f 2").read().splitlines()
+                for split_apk in split_apks:
+                    print("Extracting: " + split_apk)
+                    output = os.popen("adb -s {} pull {}".format(self.device.id, split_apk, package)).read()
+                    print(output)
             if Polar('Do you want to import the application?').ask():
                 self.do_import('base.apk')
         except Exception as e:

--- a/libraries/libmango.py
+++ b/libraries/libmango.py
@@ -393,17 +393,42 @@ class parser(cmd2.Cmd):
     def do_install(self, line):
         """Usage: install /full/path/to/foobar.apk
         Install an apk to the device."""
-
-        try:
-            if len(line.split(' ')):
-                apk_file = line.split(' ')[0]
-
+        
+        if len(line.arg_list) > 0:
+            try:
+                apk_file = line.arg_list[0]
                 if os.path.exists(apk_file):
                     self.do_adb('adb', f'install {apk_file}', True)
                 else:
-                    print(Fore.RED + f"[!] Error: can't find: {apk_file} " + Fore.RESET)
-        except Exception as e:
-            print(e)
+                    raise FileNotFoundError(Fore.RED + f"[!] Error: can't find: {apk_file}. App not installed" + Fore.RESET)
+            except FileNotFoundError as e:
+                print(e)
+        else:
+            print('[!] Usage: install /full/path/to/foobar.apk')
+
+
+    def do_installmultiple(self,line):
+        """Usage: installmultiple /full/path/to/foobar.apk /full/path/to/foobar2.apk ...
+        Install multiple apks for a single package on the device."""
+
+        if len(line.arg_list) > 1:
+            try:
+                apk_files = line.arg_list
+                adb_command = 'install-multiple'
+                for apk_file in apk_files:
+                    if os.path.exists(apk_file):
+                        adb_command += f' {apk_file}'
+                    else:
+                        raise FileNotFoundError(Fore.RED + f"[!] Error: can't find: {apk_file}. App not installed" + Fore.RESET)
+                
+                self.do_adb('adb',adb_command,True)
+            except FileNotFoundError as e:
+                print(e)
+        else:
+            print('[!] Usage: installmultiple /full/path/to/foobar.apk /full/path/to/foobar2.apk ...')
+
+
+
 
     def do_installagent(self, line):
         """Usage: installagent

--- a/libraries/libmango.py
+++ b/libraries/libmango.py
@@ -703,21 +703,14 @@ $adb remount
             print(e)
 
     def do_pull(self, line):
-        """Usage: pull [-a] com.foo.bar
+        """Usage: pull com.foo.bar
         Extracts an apk from the device and saves it as 'base.apk' in the working directory.
-        Use it in combination with the tab key to see available packages
-        '-a' flag to pull all the split_config* apks"""
+        Use it in combination with the tab key to see available packages"""
 
         if len(line.arg_list) > 0:
 
-            pull_all = False
-            package = ''
+            package = line.arg_list[0]
 
-            if line.arg_list[0] =='-a':
-                package = line.arg_list[1]
-                pull_all = True
-            else:
-                package = line.arg_list[0]
 
             try:
                 base_apk = os.popen(
@@ -725,20 +718,37 @@ $adb remount
                 print("Extracting: " + base_apk)
                 output = os.popen("adb -s {} pull {}".format(self.device.id, base_apk, package)).read()
                 print(output)
-                if pull_all:
-                    split_apks = os.popen(
-                    f"adb -s {self.device.id} shell pm path {package} | grep split | cut -d ':' -f 2").read().splitlines()
-                    for split_apk in split_apks:
-                        print("Extracting: " + split_apk)
-                        output = os.popen("adb -s {} pull {}".format(self.device.id, split_apk, package)).read()
-                        print(output)
+
                 if Polar('Do you want to import the application?').ask():
                     self.do_import('base.apk')
             except Exception as e:
                 print(e)
         else:
-            print('[!] Usage: pull [-a] com.foo.bar')
+            print('[!] Usage: pull com.foo.bar')
+
+    def do_pullmultiple(self, line):
+        """Usage: pullmultiple com.foo.bar
+        Extracts an apk and all the split_config* apk packages (from bundled apk)
+        from the device and saves it as 'base.apk' and 'split_config*'
+        in the working directory.
+        Use it in combination with the tab key to see available packages"""
+        
+        if len(line.arg_list) > 0:
+            self.do_pull(line)
+            package = line.arg_list[0]
             
+            try:
+                split_apks = os.popen(
+                f"adb -s {self.device.id} shell pm path {package} | grep split | cut -d ':' -f 2").read().splitlines()
+                for split_apk in split_apks:
+                    print("Extracting: " + split_apk)
+                    output = os.popen("adb -s {} pull {}".format(self.device.id, split_apk, package)).read()
+                    print(output)
+            except Exception as e:
+                print(e)
+        else:
+            print('[!] Usage: pullmultiple com.foo.bar')
+
 
     def do_query(self, line):
         """Usage: query SELECT * FROM [table name]
@@ -1074,6 +1084,9 @@ $adb remount
         return completions
 
     def complete_pull(self, text, line, begidx, endidx):
+        return self.get_packages_starting_with(text)
+
+    def complete_pullmultiple(self, text, line, begidx, endidx):
         return self.get_packages_starting_with(text)
 
     def complete_show(self, text, line, begidx, endidx):


### PR DESCRIPTION
This pull request solves #85 
Before completing the last step (patching), I have some doubts on the code structure, and I would like to have some input:
- for pulling all the apks, I added the `-a` flag to pull all the apks
- for installing multiple apks in a single bundle, I created a new command called `installmultiple`, where you have to insert all the apk, and the code will execute `adb install-multiple`
- I am not sure for patching if it is better to use a flag (e.g. `-a`) or create a new command. What do you think about it?
Moreover, I modified the argument parsing, from splitting the line to parsing the `arg_list`, using the Statement paramenters accordingly. Is this approach fine?
- is it fine to raise the FileNotFoundException and handle them in the except clause? 
- Finally, do you think that we should consider adding `argparse` for better argument parsing or not? Probably it is not necessary for the majority of the commands, but in some cases it could be useful