### PR TITLE
Fix country code mismatch in premium short code detection.

### DIFF
--- a/modules/sms_fraud/sms_fraud.med
+++ b/modules/sms_fraud/sms_fraud.med
@@ -160,7 +160,7 @@
             }
         }
         category = category != null ? category : 'Not short code';
-        countryCode = countryCode != null ? country : '';
+        countryCode = countryCode != null ? countryCode : '';
         return [category, countryCode];
     }
 


### PR DESCRIPTION
This fixes an error in the previously added premium number detection, that displayed the wrong country for the detected pattern.