### PR TITLE
Add patchmultiple functionality to patch bundled apks

### DIFF
--- a/libraries/libmango.py
+++ b/libraries/libmango.py
@@ -607,7 +607,7 @@ $adb remount
         if len(line.arg_list) > 0:
             self.patch_apk(line.arg_list[0])
         else:
-            print(Fore.RED + '[!] Usage: patch /full/path/to/foo.apk' + Fore.RESET)
+            logger.error("[!] Usage: patch /full/path/to/foo.apk")
         
 
 
@@ -620,7 +620,7 @@ $adb remount
             for file in line.arg_list:
                 self.patch_apk(file)
         else:
-            print(Fore.RED + '[!] Usage: patchmultiple /full/path/to/foo.apk /full/path/to/split_config.en.apk ...' + Fore.RESET)
+            logger.error("[!] Usage: patchmultiple /full/path/to/foo.apk /full/path/to/split_config.en.apk ...")
             
 
 
@@ -1708,59 +1708,59 @@ $adb remount
             ALIGNED_APK = file_name + '_debuggable' + extension
             try:
                 if not self.does_exist("apksigner"):
-                    print("[!] apksigner is not installed, quitting !")
+                    logger.error("[!] apksigner is not installed, quitting !")
                     return
                 if not self.does_exist("zipalign"):
-                    print("[!] zipalign is not installed, quitting !")
+                    logger.error("[!] zipalign is not installed, quitting !")
                     return
                 if not os.path.exists(APKTOOL):
                     if Polar('[?] apktool has not been downloaded, do you want to do it now ?').ask():
-                        print(Fore.GREEN + '[+] Downloading apktool from ' + APKTOOL_URL + ' to ' +APKTOOL)
+                        logger.info("[+] Downloading apktool from " + APKTOOL_URL + " to " +APKTOOL)
                         self.download_file(APKTOOL_URL, APKTOOL)
 
-                print(Fore.GREEN + '[+] Unpacking the apk...' + Fore.RESET)
+                logger.info("[+] Unpacking the apk...")
                 if os.path.exists(APP_FOLDER):
                     if Polar('[?] Folder' + APP_FOLDER + ' already exists. Do you want to remove the old resources?').ask():
-                        print(Fore.GREEN + '[+] Removing old resources...' + Fore.RESET)
+                        logger.info("[+] Removing old resources...")
                         shutil.rmtree(APP_FOLDER)
                     else:
-                        print(Fore.RED + '[!] The application will use the existing directory' + Fore.RESET)
+                        logger.info("[!] The application will use the existing directory")
 
                 subprocess.run('java -jar ' + APKTOOL + f' d {file} -o {APP_FOLDER}', shell=True)
 
-                print(Fore.GREEN + '[+] Extracting the manifest...' + Fore.RESET)
+                logger.info("[+] Extracting the manifest...")
                 with open(APP_FOLDER + '/AndroidManifest.xml', 'rt') as f:
                     data = f.read()
 
-                print(Fore.GREEN + '[+] Setting the debug flag to true...' + Fore.RESET)
+                logger.info("[+] Setting the debug flag to true...")
 
                 if 'android:debuggable="true"' in data:
-                    print(Fore.RED + "[!] Application is already debuggable !" + Fore.RESET)
+                    logger.error("[!] Application is already debuggable !")
                 else:
                     data = data.replace(text_to_search, replacement_text)
 
                     with open(APP_FOLDER + '/AndroidManifest.xml', 'wt') as f:
                         f.write(data)
-                    print(Fore.GREEN + '[+] Repacking the app...' + Fore.RESET)
+                    logger.info("[+] Repacking the app...")
                     subprocess.run('java -jar ' + APKTOOL + f' b {APP_FOLDER} -o {DEBUGGABLE_APK}', shell=True)
-                    print(Fore.GREEN + '[+] Aligning the apk file.....' + Fore.RESET)
+                    logger.info("[+] Aligning the apk file...")
                     subprocess.run(f'zipalign -p -v 4 {DEBUGGABLE_APK} {ALIGNED_APK}', shell=True)
-                    print(Fore.GREEN + '[+] Signing the apk.....' + Fore.RESET)
+                    logger.info("[+] Signing the apk...")
                     subprocess.run(
                         f'apksigner sign --ks {SIGNATURE} -ks-key-alias common --ks-pass pass:password --key-pass pass:password  {ALIGNED_APK}',
                         shell=True)
-                    print(Fore.GREEN + '[+] Removing the unsigned apk.....' + Fore.RESET)
+                    logger.info("[+] Removing the unsigned apk...")
                     os.remove(DEBUGGABLE_APK)
-                    print(Fore.GREEN + '[+] Original file: ' + file + Fore.RESET)
-                    print(Fore.GREEN + '[+] Debuggable file: ' + ALIGNED_APK + Fore.RESET) 
+                    logger.info("[+] Original file: " + file)
+                    logger.info("[+] Debuggable file: " + ALIGNED_APK)
 
                 if not Polar('[?] Do you want to keep the extracted resources ?').ask():
                     shutil.rmtree(APP_FOLDER)
                     if len(os.listdir(TMP_FOLDER)) == 0:
-                        print(Fore.GREEN + f'[+] {TMP_FOLDER} is empty, removing it...' + Fore.RESET)
+                        logger.info(f"[+] {TMP_FOLDER} is empty, removing it...")
                         shutil.rmtree(TMP_FOLDER)
             except Exception as e:
-                print(e)
+                logger.error(e)
 
         else:
-            print(Fore.RED + "[!] File doesn't exist." + Fore.RESET)
+            logger.error("[!] File doesn't exist.")

--- a/libraries/libmango.py
+++ b/libraries/libmango.py
@@ -1704,6 +1704,8 @@ $adb remount
         APP_FOLDER = os.path.join(TMP_FOLDER, os.path.basename(file))
 
         if os.path.exists(file):
+            file_name, extension = os.path.splitext(file)
+            ALIGNED_APK = file_name + '_debuggable' + extension
             try:
                 if not self.does_exist("apksigner"):
                     print("[!] apksigner is not installed, quitting !")
@@ -1713,12 +1715,20 @@ $adb remount
                     return
                 if not os.path.exists(APKTOOL):
                     if Polar('[?] apktool has not been downloaded, do you want to do it now ?').ask():
+                        print(Fore.GREEN + '[+] Downloading apktool from ' + APKTOOL_URL + ' to ' +APKTOOL)
                         self.download_file(APKTOOL_URL, APKTOOL)
 
-                print(Fore.GREEN + '[+] Unpacking the apk....' + Fore.RESET)
+                print(Fore.GREEN + '[+] Unpacking the apk...' + Fore.RESET)
+                if os.path.exists(APP_FOLDER):
+                    if Polar('[?] Folder' + APP_FOLDER + ' already exists. Do you want to remove the old resources?').ask():
+                        print(Fore.GREEN + '[+] Removing old resources...' + Fore.RESET)
+                        shutil.rmtree(APP_FOLDER)
+                    else:
+                        print(Fore.RED + '[!] The application will use the existing directory' + Fore.RESET)
+
                 subprocess.run('java -jar ' + APKTOOL + f' d {file} -o {APP_FOLDER}', shell=True)
 
-                print(Fore.GREEN + '[+] Extracting the manifest....' + Fore.RESET)
+                print(Fore.GREEN + '[+] Extracting the manifest...' + Fore.RESET)
                 with open(APP_FOLDER + '/AndroidManifest.xml', 'rt') as f:
                     data = f.read()
 
@@ -1741,9 +1751,8 @@ $adb remount
                         shell=True)
                     print(Fore.GREEN + '[+] Removing the unsigned apk.....' + Fore.RESET)
                     os.remove(DEBUGGABLE_APK)
-                    print(Fore.GREEN + '[+] Backing up the original...' + Fore.RESET)
-                    shutil.move(file, 'original_' + file)
-                    shutil.move(ALIGNED_APK, file)
+                    print(Fore.GREEN + '[+] Original file: ' + file + Fore.RESET)
+                    print(Fore.GREEN + '[+] Debuggable file: ' + ALIGNED_APK + Fore.RESET) 
 
                 if not Polar('[?] Do you want to keep the extracted resources ?').ask():
                     shutil.rmtree(APP_FOLDER)


### PR DESCRIPTION
This pull request solves #85, completing pull request https://github.com/Ch0pin/medusa/pull/86.

In this pull request I created the possibility to patch all the apks from a bundled app. We can use it when we have the base.apk and all the split_config. apks.
- for code reusability, I created an internal method `patch_apk` that takes a str, and I use it in both `do_patch` and `do_patchmultiple`. 
- I also added autocompletion of file arguments, to make it easier to write the file names
- when decompiling the apk, I create a single directory for each apk, in other to split all the files accordingly
- I used colorama library, and fixed some typos

Further discussion:
- I was thinking if it is necessary to have a new command or just implement `do_patch` that iterates over `arg_list`. Let me know your preferred solution
- when backing up the original, maybe it is better to keep the original apk with the initial name, and create the patched apk with an `_debuggable` extension. What do you think is the best solution? In the latter case, I can work on that.