### PR TITLE
Reset scratchpad on exit

### DIFF
--- a/medusa.py
+++ b/medusa.py
@@ -479,6 +479,7 @@ class Parser(cmd2.Cmd):
             except OSError as e:
                 logger.error(f"Failed to delete agent script: {e}")
 
+        self.edit_scratchpad('')
         print('Thank you for using Medusa !!')
         sys.exit()
 

--- a/medusa.py
+++ b/medusa.py
@@ -479,7 +479,9 @@ class Parser(cmd2.Cmd):
             except OSError as e:
                 logger.error(f"Failed to delete agent script: {e}")
 
-        self.edit_scratchpad('')
+        if self.modManager.getModule('scratchpad').Code:
+            if Polar('Do you want to reset the scratchpad?').ask():
+                self.edit_scratchpad('')
         print('Thank you for using Medusa !!')
         sys.exit()
 


### PR DESCRIPTION
When Medusa exits, it fails to clean up the scratchpad. This causes new sessions to continue with old data.